### PR TITLE
pageYOffset has better support than scrollTop

### DIFF
--- a/src/stickybits.js
+++ b/src/stickybits.js
@@ -77,7 +77,7 @@ Stickybit.prototype.manageStickiness = function manageStickiness() {
 
   // manage stickiness
   function stickiness() {
-    const scroll = win.scrollY || win.scrollTop;
+    const scroll = win.scrollY || win.pageYOffset;
     const hasStickyClass = classes.contains(stickyClass);
     const hasStuckClass = classes.contains(stuckClass);
     if (scroll < stickyBitStart) {


### PR DESCRIPTION
`win.scrollTop` is `undefined` on IE 10/11/Edge, this change fixed it.

The option `useStickyClasses` is irrelevant if the scroll value is undefined, that's why I made this change.