### PR TITLE
README.md: installed as dependency not devDependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,15 +55,15 @@
 
 yarn
 ```sh
-yarn add stickybits --dev
+yarn add stickybits
 ```
 npm
 ```sh
-npm i stickybits --save-dev
+npm i stickybits
 ```
 bower
 ```sh
-bower i stickybits --save-dev
+bower i stickybits
 ```
 
 <h2 id="setup">Setup</h2>


### PR DESCRIPTION
Please correct me if wrong, but I think stickybits should be installed as npm dependency with which code is going to be developed (it is not something like babel, webpack, grunt -- but more like jQuery or lodash). Hence I think it should not be a devDependency. The `import stickybits from 'stickybits'` says so imho.