### PR TITLE
Add --save like yarn add does

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://www.npmjs.com/package/stickybits">
     <img alt="npm version" src="https://badge.fury.io/js/stickybits.svg" />
   </a>
-  <a href="https://github.com/dollarshaveclub/stickybits"> 
+  <a href="https://github.com/dollarshaveclub/stickybits">
     <img alt="bower version" src="https://badge.fury.io/bo/stickybits.svg" />
   </a>
   <a href="https://greenkeeper.io/">
@@ -26,15 +26,15 @@
 <hr />
 <h1 align="center">StickyBits 🍬</h1>
 
-> Stickybits is a lightweight alternative to `position: sticky` polyfills. It works perfectly for things like sticky headers. 
+> Stickybits is a lightweight alternative to `position: sticky` polyfills. It works perfectly for things like sticky headers.
 
 **Stickybits is awesome because:**
 -  it can add a CSS Sticky Class (`.js-is-sticky`) when [position: sticky](http://caniuse.com/#search=sticky) elements become active and a CSS Stuck Class (`.js-is-stuck`) when they become stuck. See [useStickyClasses](#feature).
--  it loosely mimics [position: sticky](http://caniuse.com/#search=sticky) to consistently stick elements vertically across multiple platforms 
+-  it loosely mimics [position: sticky](http://caniuse.com/#search=sticky) to consistently stick elements vertically across multiple platforms
 -  it does not have the _jumpiness_ that plugins that are built around `position: fixed` have because it tries to support `position: sticky` first.
 -  in its simplest use case, a `scroll` event listener will not be used if `position: sticky` is supported.
 -  it is super simple & lightweight
--  it provides a [wiki](https://github.com/dollarshaveclub/stickybits/wiki) that digs deeply into fundementals of `position: sticky` and `position: fixed` and it works with them. 
+-  it provides a [wiki](https://github.com/dollarshaveclub/stickybits/wiki) that digs deeply into fundementals of `position: sticky` and `position: fixed` and it works with them.
 
 <hr />
   <p align="center">
@@ -59,11 +59,11 @@ yarn add stickybits
 ```
 npm
 ```sh
-npm i stickybits
+npm install stickybits --save
 ```
 bower
 ```sh
-bower i stickybits
+bower install stickybits --save
 ```
 
 <h2 id="setup">Setup</h2>
@@ -116,7 +116,7 @@ View [add css classes](#notes) for more information on StickyBits CSS Classes.
 
 By default, a StickyBits element will stick to the top of the viewport when vertically scrolled to.
 
-Stickybits loosely works for `bottom` positioning as well. 
+Stickybits loosely works for `bottom` positioning as well.
 
 To have a StickyBits element stick to the `bottom`:
 
@@ -232,19 +232,19 @@ Have another example or question? Feel free to [comment](https://github.com/doll
 
 ### Not a Polyfill
 
-Stickybits is not a Shim or Polyfill for `position: sticky` because full support would require more code. This plugin makes elements vertically sticky very similarly to `position: fixed` but in a `sticky` sort of way. Read more about position sticky [here](https://developer.mozilla.org/en-US/docs/Web/CSS/position) or follow its browser implementation [here](http://caniuse.com/#search=sticky).  
+Stickybits is not a Shim or Polyfill for `position: sticky` because full support would require more code. This plugin makes elements vertically sticky very similarly to `position: fixed` but in a `sticky` sort of way. Read more about position sticky [here](https://developer.mozilla.org/en-US/docs/Web/CSS/position) or follow its browser implementation [here](http://caniuse.com/#search=sticky).
 
-Stickybits is a no dependency JavaScript plugin. It provides the smallest API possible in both features and kb size to deliver working sticky elements. This means that opinionated featuring is left out as much as possible and that it works with minimal effort in Frameworks. 
+Stickybits is a no dependency JavaScript plugin. It provides the smallest API possible in both features and kb size to deliver working sticky elements. This means that opinionated featuring is left out as much as possible and that it works with minimal effort in Frameworks.
 
 ### CSS when `position: sticky` is not supported
 
-**Sticky Start and Sticky Stop:** Because Stickybits is minimal, when `position: sticky` is not supported Stickybits will use `position: fixed` which is relative to the browser window. If the StickyBits parent element has a height recognized by the browser, Stickybits will take care of the sticky top and sticky bottom invocation. If the parent's height is not recognized by the browser there will be issues. 
+**Sticky Start and Sticky Stop:** Because Stickybits is minimal, when `position: sticky` is not supported Stickybits will use `position: fixed` which is relative to the browser window. If the StickyBits parent element has a height recognized by the browser, Stickybits will take care of the sticky top and sticky bottom invocation. If the parent's height is not recognized by the browser there will be issues.
 
 **Left and Right Positioning:** With `position: fixed` the Stickybit element will work relative to the browser window by default. To work with this issue, there are several options. Some are noted [here](https://github.com/dollarshaveclub/stickybits/issues/66). More solutions to come!
 
 <h3 id="jquery">jQuery and Zepto Usage</h3>
 
-Basic 
+Basic
 
 ```javascript
 $('selector').stickybits();
@@ -256,7 +256,7 @@ With `scrollEl`
 const $scrollEl = $('#scrollEl')[0];
 $('selector').stickybits({scrollEl: scrollEl});
 ```
-\* **Note:** because StickyBits is _not_ jQuery specific, in order to pass in a selector for `scrollEl`, add a `[0]` to the the selector. 
+\* **Note:** because StickyBits is _not_ jQuery specific, in order to pass in a selector for `scrollEl`, add a `[0]` to the the selector.
 
 With `useStickyClasses`
 
@@ -304,19 +304,19 @@ stickybit.userAgent // will show which userAgent stickybits is detecting
 
 ## Browser Compatibility
 
-Stickybits works in all modern browsers including Internet Explorer 9 and above. Please file and [issue](https://github.com/dollarshaveclub/stickybits/issues) with browser compatibility quirks. 
+Stickybits works in all modern browsers including Internet Explorer 9 and above. Please file and [issue](https://github.com/dollarshaveclub/stickybits/issues) with browser compatibility quirks.
 
 ## Contributing
 
-Please contribute to Stickybits by filing an [issue](https://github.com/dollarshaveclub/stickybits/issues), responding to [issues](https://github.com/dollarshaveclub/stickybits/issues), adding to the [wiki](https://github.com/dollarshaveclub/stickybits/wiki), or reaching out socially—etc. 
+Please contribute to Stickybits by filing an [issue](https://github.com/dollarshaveclub/stickybits/issues), responding to [issues](https://github.com/dollarshaveclub/stickybits/issues), adding to the [wiki](https://github.com/dollarshaveclub/stickybits/wiki), or reaching out socially—etc.
 
-Stickybits is a utility. It may often not be needed! With shared understanding of `position: sticky` and `position: fixed` along with product awareness, Stickybits can improve as can a shared understanding of the "sticky element issue". Is this paragraph over-reaching? Yes! Help improve it. 
+Stickybits is a utility. It may often not be needed! With shared understanding of `position: sticky` and `position: fixed` along with product awareness, Stickybits can improve as can a shared understanding of the "sticky element issue". Is this paragraph over-reaching? Yes! Help improve it.
 
 ## Thanks
 
-This plugin was heavily influenced by [Filament Group](https://www.filamentgroup.com/)'s awesome [Fixed-sticky](https://github.com/filamentgroup/fixed-sticky) jQuery plugin. Thanks to them for getting my mind going on this a while back. Thanks to [Peloton Cycle](https://github.com/pelotoncycle/)'s [Frame Throttle](https://github.com/pelotoncycle/frame-throttle) for an insightful solve for optimizing `frame throttling`. 
+This plugin was heavily influenced by [Filament Group](https://www.filamentgroup.com/)'s awesome [Fixed-sticky](https://github.com/filamentgroup/fixed-sticky) jQuery plugin. Thanks to them for getting my mind going on this a while back. Thanks to [Peloton Cycle](https://github.com/pelotoncycle/)'s [Frame Throttle](https://github.com/pelotoncycle/frame-throttle) for an insightful solve for optimizing `frame throttling`.
 
-**Contributions:** Much browser and documentation debugging has be done by [K. Vanberendonck](https://github.com/donkeybonks). Architecture discussions and Pull Request help has been provided by [Jacob Kelley](https://github.com/jakiestfu), [Brian Gonzalez](https://github.com/briangonzalez/), and [Matt Young](https://github.com/someguynamedmatt). It is much appreciated! 
+**Contributions:** Much browser and documentation debugging has be done by [K. Vanberendonck](https://github.com/donkeybonks). Architecture discussions and Pull Request help has been provided by [Jacob Kelley](https://github.com/jakiestfu), [Brian Gonzalez](https://github.com/briangonzalez/), and [Matt Young](https://github.com/someguynamedmatt). It is much appreciated!
 
 ----
 


### PR DESCRIPTION
Hmm, I got it a bit wrong in #168 There must be `--save` for npm and bower whereas `yarn add` saves a package automatically to `package.json`.

I am seeing that my text editor also removed unneeded trailing white space. I hope you don't mind.