### PR TITLE
Fix typo in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Stickybits 2.0 provides the same API but with more debugging feedback.
 To view the Stickybits API in it's simpliest form:
 ```javascript
 var stickybit = stickybits('a selection')
-console.log(stickbit)
+console.log(stickybit)
 ```
 
 For more debugging and managing Stickbits, view the [wiki](https://github.com/dollarshaveclub/stickybits/wiki).


### PR DESCRIPTION
Fix typo in code example