### PR TITLE
Renames "plugin" variable to "library" in jQuery and Umbrella plugins

### DIFF
--- a/src/jquery.stickybits.js
+++ b/src/jquery.stickybits.js
@@ -1,9 +1,9 @@
 import stickybits from './stickybits'
 
 if (typeof window !== 'undefined') {
-  const plugin = window.$ || window.jQuery || window.Zepto
-  if (plugin) {
-    plugin.fn.stickybits = function stickybitsPlugin (opts) {
+  const library = window.$ || window.jQuery || window.Zepto
+  if (library) {
+    library.fn.stickybits = function stickybitsPlugin (opts) {
       return stickybits(this, opts)
     }
   }

--- a/src/umbrella.stickybits.js
+++ b/src/umbrella.stickybits.js
@@ -1,9 +1,9 @@
 import stickybits from './stickybits'
 
 if (typeof window !== 'undefined') {
-  const plugin = window.u
-  if (plugin) {
-    plugin.prototype.stickybits = function stickybitsPlugin (opts) {
+  const library = window.u
+  if (library) {
+    library.prototype.stickybits = function stickybitsPlugin (opts) {
       return stickybits(this, opts)
     }
   }


### PR DESCRIPTION
Fixes misleading variable name.