### PR TITLE
Improves readability of elements instantiation in constructor

### DIFF
--- a/src/stickybits.js
+++ b/src/stickybits.js
@@ -72,30 +72,40 @@ class Stickybits {
       useGetBoundingClientRect: o.useGetBoundingClientRect || false,
       verticalPosition: o.verticalPosition || 'top',
     }
-    this.props.positionVal = this.definePosition()
+    /*
+      define positionVal
+      ----
+      -  uses a computed (`.definePosition()`)
+      -  defined the position
+    */
+    this.props.positionVal = this.definePosition() || 'fixed'
 
     this.instances = []
 
-    const {positionVal, verticalPosition, noStyles, stickyBitStickyOffset, useStickyClasses} = this.props
-    const hasNativeSupport = positionVal !== 'fixed'
+    const {
+      positionVal,
+      verticalPosition,
+      noStyles,
+      stickyBitStickyOffset,
+      useStickyClasses,
+    } = this.props
     const verticalPositionStyle = verticalPosition === 'top' && !noStyles ? `${stickyBitStickyOffset}px` : ''
-    const positionStyle = hasNativeSupport ? positionVal : ''
+    const positionStyle = positionVal !== 'fixed' ? positionVal : ''
 
     this.els = typeof target === 'string' ? document.querySelectorAll(target) : target
 
-    if (!('length' in this.els)) {
-      this.els = [this.els]
-    }
+    if (!('length' in this.els)) this.els = [this.els]
 
     for (let i = 0; i < this.els.length; i++) {
       const el = this.els[i]
 
+      // set vertical position
       el.style[verticalPosition] = verticalPositionStyle
       el.style.position = positionStyle
 
-      if (!hasNativeSupport || useStickyClasses) {
+      if (positionVal === 'fixed' || useStickyClasses) {
         const instance = this.addInstance(el, this.props)
-
+        // instances are an array of objects
         this.instances.push(instance)
       }
     }

--- a/src/stickybits.js
+++ b/src/stickybits.js
@@ -72,32 +72,34 @@ class Stickybits {
       useGetBoundingClientRect: o.useGetBoundingClientRect || false,
       verticalPosition: o.verticalPosition || 'top',
     }
-    const p = this.props
-    /*
-      define positionVal
-      ----
-      -  uses a computed (`.definePosition()`)
-      -  defined the position
-    */
-    p.positionVal = this.definePosition() || 'fixed'
-    const vp = p.verticalPosition
-    const ns = p.noStyles
-    const pv = p.positionVal
-    this.els = typeof target === 'string' ? document.querySelectorAll(target) : target
-    if (!('length' in this.els)) this.els = [this.els]
+    this.props.positionVal = this.definePosition()
+
     this.instances = []
-    for (let i = 0; i < this.els.length; i += 1) {
+
+    const {positionVal, verticalPosition, noStyles, stickyBitStickyOffset, useStickyClasses} = this.props
+    const hasNativeSupport = positionVal !== 'fixed'
+    const verticalPositionStyle = verticalPosition === 'top' && !noStyles ? `${stickyBitStickyOffset}px` : ''
+    const positionStyle = hasNativeSupport ? positionVal : ''
+
+    this.els = typeof target === 'string' ? document.querySelectorAll(target) : target
+
+    if (!('length' in this.els)) {
+      this.els = [this.els]
+    }
+
+    for (let i = 0; i < this.els.length; i++) {
       const el = this.els[i]
-      const styles = el.style
-      // set vertical position
-      styles[vp] = vp === 'top' && !ns ? `${p.stickyBitStickyOffset}px` : ''
-      styles.position = pv !== 'fixed' ? pv : ''
-      if (pv === 'fixed' || p.useStickyClasses) {
-        const instance = this.addInstance(el, p)
-        // instances are an array of objects
+
+      el.style[verticalPosition] = verticalPositionStyle
+      el.style.position = positionStyle
+
+      if (!hasNativeSupport || useStickyClasses) {
+        const instance = this.addInstance(el, this.props)
+
         this.instances.push(instance)
       }
     }
+
     return this
   }
 


### PR DESCRIPTION
Basically this PR brings more readable variable names and some empty lines to separate unrelated code. Since `definePosition` always returns some or another truthy value I've removed fallback from the constructor.

No breaking changes this time, although I think `this.els` should be a local variable and not attached to the instance, but since somebody can be relying on this I kept it.