### PR TITLE
Removes return from the constructor

### DIFF
--- a/src/stickybits.js
+++ b/src/stickybits.js
@@ -98,7 +98,6 @@ class Stickybits {
         this.instances.push(instance)
       }
     }
-    return this
   }
 
   /*


### PR DESCRIPTION
Constructor doesn't have to return `this` - it's implicit and usually not done explicitly.