### PR TITLE
Match scrollEl  type with real interface

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,7 +13,7 @@ export namespace StickyBits {
     noStyles?: boolean
     stickyBitStickyOffset?: number
     parentClass?: string
-    scrollEl?: Element
+    scrollEl?: Element | string
     stickyClass?: string
     stuckClass?: string
     stickyChangeClass?: string


### PR DESCRIPTION

## Proposed Changes

- match type interface with reality. scrollEl can be both string and Element


----


