### PR TITLE
Prevent race condition between change toggles

### DIFF
--- a/src/stickybits.js
+++ b/src/stickybits.js
@@ -351,7 +351,7 @@ class Stickybits {
     }
 
     const isStickyChange = scroll >= change && scroll <= stop
-    const isNotStickyChange = scroll < change || scroll > stop
+    const isNotStickyChange = scroll < change / 2 || scroll > stop
     const stub = 'stub' // a stub css class to remove
     if (isNotStickyChange) {
       rAF(() => { tC(e, stickyChange) })


### PR DESCRIPTION
This addresses a race condition that happens when sticky element's height shrink when it reaches `--changed` state. It was previously reported in #234 but never fixed. This feels like a pretty common case how `--changed` state is used.

What happens in this case is the following:

- We scroll down so we enter the `--changed` state
- CSS that makes the element smaller kicks in
- Because the element became smaller, `window.scrollX` also decreases, this triggers another update cycle
- In case we didn't scroll very far down it's possible that we enter a non-changed state so we toggle classes and sticky elements gets bigger
- Race condition state is entered, so the page jumps and wobbles

Here's a GIF of this behavior in our app:

![wobble](https://user-images.githubusercontent.com/944286/50445469-9a5a0780-0917-11e9-906a-d6d782f658c8.gif)

There are multiple options how this can be addressed. Here are the ones I can think of:

1. Use different threshold based on original `stickyChangeOffset` for transitioning back into non-changed state (currently implemented)
    - Pros: very straightforward change which should work for most cases
    - Cons: issue would still be possible if sticky element gets real small
1. Use different threshold based on the height of the sticky element after we transitioned into changed state
    - Pros: should completely eliminate the possibility of the issue
    - Cons: requires more non-trivial computation
1. Introduce a new config option similar to `stickyChangeOffset` to allow specifying the non-changed threshold
    - Pros: users can control the transition manually
    - Cons: more knobs

Please let me know what you think!