### PR TITLE
Fixed the correct initial calculation of the offset.

### DIFF
--- a/src/stickybits.js
+++ b/src/stickybits.js
@@ -237,7 +237,7 @@ class Stickybits {
       : el.offsetHeight
     const parentBottom = stickyStart + parent.offsetHeight
     it.offset = scrollElOffset + p.stickyBitStickyOffset
-    it.stickyStart = isTop ? stickyStart - it.offset : 0
+    it.stickyStart = isTop ? stickyStart : 0
     it.stickyChange = it.stickyStart + stickyChangeOffset
     it.stickyStop = isTop
       ? parentBottom - (el.offsetHeight + it.offset)
@@ -330,7 +330,7 @@ class Stickybits {
         stl.position = pv
         if (ns) return
         stl.bottom = ''
-        stl[vp] = `${p.stickyBitStickyOffset}px`
+        stl[vp] = `${it.offset}px`
       })
     } else if (isSticky) {
       it.state = 'default'


### PR DESCRIPTION
## Fixes

It fixes for my project the issues with the initial calculation of the offsets


## Proposed Changes

- Change
Initial stickyStart calculation
Offset used for sticky state, is the offset calculated in the computeScrollOffsets function
----

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.

Resolves #455 