### PR TITLE
Removed --dev dep install description, mentioned in issue #504

### DIFF
--- a/page/index.html
+++ b/page/index.html
@@ -101,10 +101,10 @@
                     <section id="installation" class=" section section--installation">
                         <h2>Install</h2>
                         <h3>yarn</h3>
-                        <div><pre><code>yarn add stickybits --dev</code></pre>
+                        <div><pre><code>yarn add stickybits</code></pre>
                         </div>
                         <h3>npm</h3>
-                        <div><pre><code>npm install stickybits --save-dev</code></pre></div>
+                        <div><pre><code>npm install stickybits</code></pre></div>
                         <section id="setup" class="section section--setup">
                             <h2>Setup</h2>
                             <h3>Default</h3>


### PR DESCRIPTION
## Fixes

- Fixes #504 

## Proposed Changes

- Removed the --dev from the github page, as you need to install stickybits as direct dependency.

----

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.

Thanks to @theiliad for mentioning it!