### PR TITLE
Add applyStyle property

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,21 @@ stickybits('selector', {useGetBoundingClientRect: true});
 
 \* For jQuery and Zepto support, read the jQuery notes [below](#jquery).
 
+### StickyBits applyStyle
+
+If you want to take control of how styles and classes are applied to elements
+provide a function `applyStyle`. This is useful for example if you want to
+integrate with a framework or view library and want to delegate DOM
+manipulations to it.
+
+``` javascript
+stickybits('selector', {
+  applyStyle: ({ classes, styles }, instance) => {
+    // Apply styles and classes to your element
+  }
+});
+```
+
 ## Examples
 
 - [Basic Usage](https://codepen.io/yowainwright/pen/QdedaO)

--- a/tests/unit/test.stickybits.js
+++ b/tests/unit/test.stickybits.js
@@ -82,6 +82,14 @@ test('stickybits interface with custom scrollEl element', () => {
   expect(stickybit.props.scrollEl).toBe(document.querySelector('#parent'))
 })
 
+test('stickybits interface with custom applyStyle function', () => {
+  const fn = jest.fn(() => {})
+  document.body.innerHTML = '<div id="parent"><div id="stickybit"></div></div>'
+  stickybits("#stickybit", { applyStyle: fn })
+
+  expect(fn).toHaveBeenCalled()
+})
+
 test('stickybits .addInstance interface', () => {
   document.body.innerHTML = '<div id="manage-sticky"></div>'
   const e = document.getElementById('manage-sticky')


### PR DESCRIPTION
This property allows the user to control how they want to apply the
styles and classes.

## Fixes

- Fixes #598

## Proposed Changes

- Change how styles and classes are applied to use a single function, `applyStyle`, which users can provide to take control over how to apply them (useful e.g. when a framework like Elm).
- Update interface for `toggleClasses` to take a an object of classes where the key is the class name and the value's truthiness determines if it should be added or removed.
- Do only a single call to `applyStyle` and only when a state changes.
