### PR TITLE
Only add parent class once

### DIFF
--- a/src/stickybits.js
+++ b/src/stickybits.js
@@ -175,7 +175,7 @@ class Stickybits {
       this.isWin = this.props.scrollEl === window
       const se = this.isWin ? window : this.getClosestParent(item.el, item.props.scrollEl)
       this.computeScrollOffsets(item)
-      item.parent.className += ` ${props.parentClass}`
+      this.toggleClasses(item.parent, '', props.parentClass)
       item.state = 'default'
       item.stateChange = 'default'
       item.stateContainer = () => this.manageState(item)

--- a/tests/unit/test.stickybits.js
+++ b/tests/unit/test.stickybits.js
@@ -63,6 +63,16 @@ test('stickybits interface with an updated object properties', () => {
   expect(stickybit.props.positionVal).toBe('-ms-sticky')
 })
 
+test('stickybits only appends parent class once', () => {
+  document.body.innerHTML = '<div id="parent"><div class="child"></div><div class="child"></div></div>'
+  const stickybit = stickybits('.child', {
+    useStickyClasses: true
+  });
+
+  const parent = document.querySelector('#parent');
+  expect(parent.className).toBe(stickybit.props.parentClass);
+})
+
 test('stickybits interface with custom scrollEl selector', () => {
   document.body.innerHTML = '<div id="parent"><div id="stickybit"></div></div>'
   const stickybit = stickybits('#stickybit', {


### PR DESCRIPTION
## Fixes

- Fixes #621

## Proposed Changes

- Change `addInstance` to add the parent class only once instead of multiple times.

----

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
