### PR TITLE
Only set position absolute if useFixed is true

### DIFF
--- a/src/stickybits.js
+++ b/src/stickybits.js
@@ -322,7 +322,6 @@ class Stickybits {
     const notSticky = scroll > start && scroll < stop && (state === 'default' || state === 'stuck')
     const isSticky = isTop && scroll <= start && (state === 'sticky' || state === 'stuck')
     const isStuck = scroll >= stop && state === 'sticky'
-
     /*
       Unnamed arrow functions within this block
       ---
@@ -368,10 +367,12 @@ class Stickybits {
         },
         stuck: {
           styles: {
-            position: 'absolute',
-            top: '',
-            bottom: '0',
             [vp]: '',
+            ...(pv === 'fixed' ? {
+              position: 'absolute',
+              top: '',
+              bottom: '0',
+            } : {})
           },
           classes: { [stuck]: true },
         },
@@ -422,12 +423,10 @@ class Stickybits {
 
     e.className = cArray.join(' ')
 
+    if (ns) return
+
     // eslint-disable-next-line no-unused-vars
     for (const key in styles) {
-      if (ns && key === 'position') {
-        stl[key] = styles[key]
-        return
-      }
       stl[key] = styles[key]
     }
   }

--- a/tests/unit/test.stickybits.js
+++ b/tests/unit/test.stickybits.js
@@ -100,6 +100,68 @@ test('stickybits interface with custom applyStyle function', () => {
   expect(fn).toHaveBeenCalled()
 })
 
+test("stickybits doesn't applyStyles if noStyles is true", () => {
+  document.body.innerHTML = '<div id="parent"></div>'
+  const stickybit = stickybits('#parent', {
+    noStyles: true,
+  });
+
+  const item = stickybit.instances[0];
+  stickybit.applyStyle({ position: 'absolute', classes: [] }, item)
+
+  const parent = document.querySelector('#parent');
+  expect(parent.style['position']).toBe('');
+})
+
+test("stickybits sets position absolute if the element is fixed", () => {
+  document.body.innerHTML = '<div id="parent"></div>'
+  const stickybit = stickybits('#parent', { useFixed: true });
+
+  const item = stickybit.instances[0];
+  item.state = 'sticky';
+  stickybit.isWin = false;
+  item.props.scrollEl = { scrollTop: 200 };
+  item.stickyStart = 0;
+  item.stickyStop = 200;
+  stickybit.manageState(item)
+
+  const parent = document.querySelector('#parent');
+  expect(parent.style['position']).toBe('absolute');
+})
+
+test("stickybits doesn't change position style if the element isn't fixed", () => {
+  document.body.innerHTML = '<div id="parent"></div>'
+  const stickybit = stickybits('#parent');
+  const parent = document.querySelector('#parent');
+  const positionStyle = parent.style['position'];
+
+  const item = stickybit.instances[0];
+  item.state = 'sticky';
+  stickybit.isWin = false;
+  item.props.scrollEl = { scrollTop: 200 };
+  item.stickyStart = 0;
+  item.stickyStop = 200;
+  stickybit.manageState(item)
+
+  expect(parent.style['position']).toBe(positionStyle);
+})
+
+test("stickybits sets position absolute if the element is fixed", () => {
+  document.body.innerHTML = '<div id="parent"></div>'
+  const stickybit = stickybits('#parent', { useFixed: true });
+
+  const item = stickybit.instances[0];
+  item.state = 'sticky';
+  stickybit.isWin = false;
+  item.props.scrollEl = { scrollTop: 200 };
+  item.stickyStart = 0;
+  item.stickyStop = 200;
+  stickybit.manageState(item)
+
+  const parent = document.querySelector('#parent');
+  expect(parent.style['position']).toBe('absolute');
+})
+
 test('stickybits .addInstance interface', () => {
   document.body.innerHTML = '<div id="manage-sticky"></div>'
   const e = document.getElementById('manage-sticky')


### PR DESCRIPTION
Additionally always respect if noStyles is true when running applyStyles.

## Fixes

- Fixes #630 

## Proposed Changes

- Change `applyStyles` to not modify any styles if `noStyles` is set to true;
- Change `manageState` to conditionally set `position: 'absolute'` only if `position: 'fixed'`.

----

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
