### PR TITLE
Apply position regardless of noStyles

### DIFF
--- a/src/stickybits.js
+++ b/src/stickybits.js
@@ -422,6 +422,10 @@ class Stickybits {
 
     e.className = cArray.join(' ')
 
+    if(styles['position']) {
+      stl['position'] = styles['position'];
+    }
+
     if (ns) return
 
     // eslint-disable-next-line no-unused-vars

--- a/tests/unit/test.stickybits.js
+++ b/tests/unit/test.stickybits.js
@@ -107,10 +107,23 @@ test("stickybits doesn't applyStyles if noStyles is true", () => {
   });
 
   const item = stickybit.instances[0];
-  stickybit.applyStyle({ position: 'absolute', classes: [] }, item)
+  stickybit.applyStyle({ styles: { color: 'red' }, classes: [] }, item)
 
   const parent = document.querySelector('#parent');
-  expect(parent.style['position']).toBe('');
+  expect(parent.style['color']).toBe('');
+})
+
+test("stickybits sets position even with noStyles true", () => {
+  document.body.innerHTML = '<div id="parent"></div>'
+  const stickybit = stickybits('#parent', {
+    noStyles: true,
+  });
+
+  const item = stickybit.instances[0];
+  stickybit.applyStyle({ styles: { position: 'absolute' }, classes: [] }, item)
+
+  const parent = document.querySelector('#parent');
+  expect(parent.style['position']).toBe('absolute');
 })
 
 test("stickybits sets position absolute if the element is fixed", () => {


### PR DESCRIPTION
## Fixes

- Fixes #646

## Proposed Changes

- Change `applyStyle` to apply `position` even if `noStyles` is set to true.

----

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
