### PR TITLE
Fix position:absolute and no initial call to manageState

### DIFF
--- a/src/stickybits.js
+++ b/src/stickybits.js
@@ -295,6 +295,7 @@ class Stickybits {
     const vp = p.verticalPosition
     const isTop = vp !== 'bottom'
     const aS = p.applyStyle
+    const ns = p.noStyles
     /*
       requestAnimationFrame
       ---
@@ -367,7 +368,7 @@ class Stickybits {
         stuck: {
           styles: {
             [vp]: '',
-            ...(pv === 'fixed' || !this.isWin ? {
+            ...(pv === 'fixed' && !ns ? {
               position: 'absolute',
               top: '',
               bottom: '0',

--- a/src/stickybits.js
+++ b/src/stickybits.js
@@ -111,6 +111,7 @@ class Stickybits {
         },
         instance,
       )
+      this.manageState(instance)
 
       // instances are an array of objects
       this.instances.push(instance)

--- a/tests/unit/test.stickybits.js
+++ b/tests/unit/test.stickybits.js
@@ -93,14 +93,22 @@ test('stickybits interface with custom scrollEl element', () => {
 })
 
 test('stickybits interface with custom applyStyle function', () => {
-  const fn = jest.fn(() => {})
+  const applyStyle = jest.fn(() => {})
   document.body.innerHTML = '<div id="parent"><div id="stickybit"></div></div>'
-  stickybits("#stickybit", { applyStyle: fn })
+  const stickybit = stickybits("#stickybit", { applyStyle })
 
-  expect(fn).toHaveBeenCalled()
+  const item = stickybit.instances[0];
+  item.state = 'sticky';
+  stickybit.isWin = false;
+  item.props.scrollEl = { scrollTop: 200 };
+  item.stickyStart = 0;
+  item.stickyStop = 200;
+  stickybit.manageState(item)
+
+  expect(applyStyle).toHaveBeenCalled()
 })
 
-test("stickybits doesn't applyStyles if noStyles is true", () => {
+test("stickybits doesn't apply styles if noStyles is true", () => {
   document.body.innerHTML = '<div id="parent"></div>'
   const stickybit = stickybits('#parent', {
     noStyles: true,

--- a/tests/unit/test.stickybits.js
+++ b/tests/unit/test.stickybits.js
@@ -159,20 +159,21 @@ test("stickybits doesn't change position style if the element isn't fixed", () =
   expect(parent.style['position']).toBe(positionStyle);
 })
 
-test("stickybits sets position absolute if the element is fixed", () => {
+test("stickybits doesn't change position style if noStyles is true", () => {
   document.body.innerHTML = '<div id="parent"></div>'
-  const stickybit = stickybits('#parent', { useFixed: true });
+  const stickybit = stickybits('#parent');
+  const parent = document.querySelector('#parent');
+  const positionStyle = parent.style['position'];
 
   const item = stickybit.instances[0];
   item.state = 'sticky';
-  stickybit.isWin = false;
+  stickybit.isWin = true;
   item.props.scrollEl = { scrollTop: 200 };
   item.stickyStart = 0;
   item.stickyStop = 200;
   stickybit.manageState(item)
 
-  const parent = document.querySelector('#parent');
-  expect(parent.style['position']).toBe('absolute');
+  expect(parent.style['position']).toBe(positionStyle);
 })
 
 test('stickybits .addInstance interface', () => {


### PR DESCRIPTION
## Fixes

- Fixes #642 
- Fixes #582 

## Proposed Changes

- Fix the conditional which applied `position: absolute`, it got messed up when I changed to using `applyStyle`;
- Add an initial call to `manageState` in the constructor to add the correct classes and styles when someone refreshes in the middle of the page.

----

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
